### PR TITLE
[Core] Fixed "int" default value skipped

### DIFF
--- a/src/Orm/lib/class.ormcore.php
+++ b/src/Orm/lib/class.ormcore.php
@@ -74,7 +74,7 @@ class OrmCore {
 			}
 			
 			//Manage the default value
-			if($field->getDefaultValue() != null){
+			if(!is_null($field->getDefaultValue())){
 				if($field->getType() == OrmCAST::$STRING || $field->getType() == OrmCAST::$BUFFER) {
 					$hql .= "  DEFAULT '".str_replace("'", "''",$field->getDefaultValue())."' ";
 				} else {


### PR DESCRIPTION
Default value 0 was not ok as "!= null" test was "true" with int value =
0.

http://www.php.net/manual/en/function.is-null.php
