### PR TITLE
[Core] Fix no clause is no values passed to IN

### DIFF
--- a/src/Orm/lib/class.OrmCore.php
+++ b/src/Orm/lib/class.OrmCore.php
@@ -892,6 +892,9 @@ class OrmCore {
 						}
 						$hql .= ' )';
 				}
+				else if(is_array($criteria->paramsCriteria) && count($criteria->paramsCriteria) == 0) {
+					$hql .= 'AND false '; // no value passed, so no result to be returned
+				}
 				continue;
 		 }
 		


### PR DESCRIPTION
Result was that if in-where clause was empty, ni filter was applied so
all values were accepted.

Now if no values, then "AND false" added so that no rows will be
returned.
